### PR TITLE
Added Docker image support for ARM64 (Raspberry PI) + Github Actions builds

### DIFF
--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -52,23 +52,18 @@ jobs:
       run: |
          find .
       shell: bash
-    - name: Run Buildx amd64
+    - name: Run Buildx osp-core
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
         echo Version: $VERSION
-        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./docker-build/osp-core
-    - name: Run Buildx arm64
+        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/arm64,linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} -t devedse/osp-core:latest ${{ github.ref == 'refs/heads/master' && '--push' || '' }} ./docker-build/osp-core
+    - name: Run Buildx osp-rtmp
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
         echo Version: $VERSION
-        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/arm64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./docker-build/osp-core
-    - name: Run Buildx arm
+        docker buildx build -f docker-build/osp-rtmp/Dockerfile --platform linux/arm64,linux/amd64 -t devedse/osp-rtmp:${{needs.generate_version_number.outputs.build_number}} -t devedse/osp-rtmp:latest ${{ github.ref == 'refs/heads/master' && '--push' || '' }} ./docker-build/osp-rtmp
+    - name: Run Buildx osp-ejabberd
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
         echo Version: $VERSION
-        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/arm -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./docker-build/osp-core
-    - name: Run Buildx all
-      run: |
-        export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
-        echo Version: $VERSION
-        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/arm,linux/arm64,linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./docker-build/osp-core
+        docker buildx build -f docker-build/osp-ejabberd/Dockerfile --platform linux/arm64,linux/amd64 -t devedse/osp-ejabberd:${{needs.generate_version_number.outputs.build_number}} -t devedse/osp-ejabberd:latest ${{ github.ref == 'refs/heads/master' && '--push' || '' }} ./docker-build/osp-ejabberd

--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -43,4 +43,4 @@ jobs:
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
         echo Version: $VERSION
-        docker buildx build -f installs/docker/OSP-Core/Dockerfile --platform linux/arm,linux/arm64,linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./installs/docker/OSP-Core/Dockerfile
+        docker buildx build -f installs/docker/OSP-Core/Dockerfile --platform linux/arm,linux/arm64,linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./installs/docker/OSP-Core

--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -52,7 +52,22 @@ jobs:
       run: |
          find .
       shell: bash
-    - name: Run Buildx
+    - name: Run Buildx amd64
+      run: |
+        export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
+        echo Version: $VERSION
+        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./docker-build/osp-core
+    - name: Run Buildx arm64
+      run: |
+        export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
+        echo Version: $VERSION
+        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/arm64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./docker-build/osp-core
+    - name: Run Buildx arm
+      run: |
+        export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
+        echo Version: $VERSION
+        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/arm -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./docker-build/osp-core
+    - name: Run Buildx all
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
         echo Version: $VERSION

--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -1,0 +1,46 @@
+name: GitHubActionsBuilds
+
+on: push
+
+jobs:
+  generate_version_number:
+    runs-on: ubuntu-latest
+    outputs:
+      build_number: ${{ steps.buildnumber.outputs.build_number }}
+    steps:
+    - name: Generate build number
+      id: buildnumber
+      uses: einaregilsson/build-number@v3
+      with:
+        token: ${{secrets.github_token}}
+
+  build_docker:
+    needs: generate_version_number
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # - name: Login to Docker Hub
+    #   uses: docker/login-action@v1
+    #   with:
+    #     username: devedse
+    #     password: ${{ secrets.DOCKERHUBTOKEN }}
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+    - name: Available platforms
+      run: echo ${{ steps.qemu.outputs.platforms }}
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Builder instance name
+      run: echo ${{ steps.buildx.outputs.name }}
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+    - name: Run Buildx
+      run: |
+        export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
+        echo Version: $VERSION
+        docker buildx build -f installs/docker/OSP-Core/Dockerfile --platform linux/arm,linux/arm64,linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./installs/docker/OSP-Core/Dockerfile

--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -44,6 +44,14 @@ jobs:
          chmod +x ./build-docker-directory.sh
          ./build-docker-directory.sh
       shell: bash
+    - name: Run script file
+      run: |
+         find docker-build
+      shell: bash
+    - name: Tree123
+      run: |
+         find .
+      shell: bash
     - name: Run Buildx
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}

--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -39,6 +39,11 @@ jobs:
       run: echo ${{ steps.buildx.outputs.name }}
     - name: Available platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
+    - name: Run script file
+      run: |
+         chmod +x ./build-docker-directory.sh
+         ./build-docker-directory.sh
+      shell: bash
     - name: Run Buildx
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}

--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -14,16 +14,16 @@ jobs:
       with:
         token: ${{secrets.github_token}}
 
-  build_docker:
+  build_docker_osp-core:
     needs: generate_version_number
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    # - name: Login to Docker Hub
-    #   uses: docker/login-action@v1
-    #   with:
-    #     username: devedse
-    #     password: ${{ secrets.DOCKERHUBTOKEN }}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: devedse
+        password: ${{ secrets.DOCKERHUBTOKEN }}
     - name: Set up QEMU
       id: qemu
       uses: docker/setup-qemu-action@v1
@@ -57,11 +57,89 @@ jobs:
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
         echo Version: $VERSION
         docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/arm64,linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} -t devedse/osp-core:latest ${{ github.ref == 'refs/heads/master' && '--push' || '' }} ./docker-build/osp-core
+
+  build_docker_osp-rtmp:
+    needs: generate_version_number
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: devedse
+        password: ${{ secrets.DOCKERHUBTOKEN }}
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+    - name: Available platforms
+      run: echo ${{ steps.qemu.outputs.platforms }}
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Builder instance name
+      run: echo ${{ steps.buildx.outputs.name }}
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+    - name: Run script file
+      run: |
+         chmod +x ./build-docker-directory.sh
+         ./build-docker-directory.sh
+      shell: bash
+    - name: Run script file
+      run: |
+         find docker-build
+      shell: bash
+    - name: Tree123
+      run: |
+         find .
+      shell: bash
     - name: Run Buildx osp-rtmp
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
         echo Version: $VERSION
         docker buildx build -f docker-build/osp-rtmp/Dockerfile --platform linux/arm64,linux/amd64 -t devedse/osp-rtmp:${{needs.generate_version_number.outputs.build_number}} -t devedse/osp-rtmp:latest ${{ github.ref == 'refs/heads/master' && '--push' || '' }} ./docker-build/osp-rtmp
+
+  build_docker_osp-ejabberd:
+    needs: generate_version_number
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: devedse
+        password: ${{ secrets.DOCKERHUBTOKEN }}
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+    - name: Available platforms
+      run: echo ${{ steps.qemu.outputs.platforms }}
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Builder instance name
+      run: echo ${{ steps.buildx.outputs.name }}
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+    - name: Run script file
+      run: |
+         chmod +x ./build-docker-directory.sh
+         ./build-docker-directory.sh
+      shell: bash
+    - name: Run script file
+      run: |
+         find docker-build
+      shell: bash
+    - name: Tree123
+      run: |
+         find .
+      shell: bash
     - name: Run Buildx osp-ejabberd
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}

--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -48,10 +48,6 @@ jobs:
       run: |
          find docker-build
       shell: bash
-    - name: Tree123
-      run: |
-         find .
-      shell: bash
     - name: Run Buildx osp-core
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
@@ -92,10 +88,6 @@ jobs:
       run: |
          find docker-build
       shell: bash
-    - name: Tree123
-      run: |
-         find .
-      shell: bash
     - name: Run Buildx osp-rtmp
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
@@ -135,10 +127,6 @@ jobs:
     - name: Run script file
       run: |
          find docker-build
-      shell: bash
-    - name: Tree123
-      run: |
-         find .
       shell: bash
     - name: Run Buildx osp-ejabberd
       run: |

--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -56,4 +56,4 @@ jobs:
       run: |
         export VERSION=1.0.${{needs.generate_version_number.outputs.build_number}}
         echo Version: $VERSION
-        docker buildx build -f installs/docker/OSP-Core/Dockerfile --platform linux/arm,linux/arm64,linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./installs/docker/OSP-Core
+        docker buildx build -f docker-build/osp-core/Dockerfile --platform linux/arm,linux/arm64,linux/amd64 -t devedse/osp-core:${{needs.generate_version_number.outputs.build_number}} ./docker-build/osp-core

--- a/installs/docker/Ejabberd/Dockerfile
+++ b/installs/docker/Ejabberd/Dockerfile
@@ -1,7 +1,8 @@
 #FROM ejabberd/ecs:20.04
 #FROM ugeek/ejabberd:arm64
 #FROM sando38/docker-ejabberd-multiarch
-FROM andrejunqueira33/ejabberd-new:1.0.0
+#FROM andrejunqueira33/ejabberd-new:1.0.0
+FROM ghcr.io/processone/ejabberd:master
 MAINTAINER David Lockwood
 
 # OSP Customized EJABBERD Docker Container

--- a/installs/docker/Ejabberd/Dockerfile
+++ b/installs/docker/Ejabberd/Dockerfile
@@ -1,8 +1,8 @@
 #FROM ejabberd/ecs:20.04
 #FROM ugeek/ejabberd:arm64
 #FROM sando38/docker-ejabberd-multiarch
-#FROM andrejunqueira33/ejabberd-new:1.0.0
-FROM ghcr.io/processone/ejabberd:master
+FROM andrejunqueira33/ejabberd-new:1.0.0
+#FROM ghcr.io/processone/ejabberd:master
 MAINTAINER David Lockwood
 
 # OSP Customized EJABBERD Docker Container

--- a/installs/docker/Ejabberd/Dockerfile
+++ b/installs/docker/Ejabberd/Dockerfile
@@ -1,8 +1,8 @@
 #FROM ejabberd/ecs:20.04
 #FROM ugeek/ejabberd:arm64
 #FROM sando38/docker-ejabberd-multiarch
-FROM andrejunqueira33/ejabberd-new:1.0.0
-#FROM ghcr.io/processone/ejabberd:master
+#FROM andrejunqueira33/ejabberd-new:1.0.0
+FROM ghcr.io/processone/ejabberd:master
 MAINTAINER David Lockwood
 
 # OSP Customized EJABBERD Docker Container
@@ -47,15 +47,15 @@ COPY docker-files.d/supervisord.conf /run/supervisord.conf
 
 USER ejabberd
 
-RUN mkdir /home/ejabberd/run
-COPY docker-files.d/ejabberd.yml /home/ejabberd/run/ejabberd.yml
-COPY docker-files.d/auth_osp.py /home/ejabberd/run/auth_osp.py
-COPY docker-files.d/inetrc /home/ejabberd/conf/inetrc
+RUN mkdir /opt/ejabberd/run
+COPY docker-files.d/ejabberd.yml /opt/ejabberd/run/ejabberd.yml
+COPY docker-files.d/auth_osp.py /opt/ejabberd/run/auth_osp.py
+COPY docker-files.d/inetrc /opt/ejabberd/conf/inetrc
 
 EXPOSE 5222
 EXPOSE 5280
 
 USER root
-VOLUME ["/home/ejabberd/database"]
+VOLUME ["/opt/ejabberd/database"]
 
 ENTRYPOINT ["/bin/sh","-c", "/run/entrypoint.sh"]

--- a/installs/docker/Ejabberd/Dockerfile
+++ b/installs/docker/Ejabberd/Dockerfile
@@ -1,6 +1,7 @@
 #FROM ejabberd/ecs:20.04
-FROM ugeek/ejabberd:arm64
+#FROM ugeek/ejabberd:arm64
 #FROM sando38/docker-ejabberd-multiarch
+FROM andrejunqueira33/ejabberd-new:1.0.0
 MAINTAINER David Lockwood
 
 # OSP Customized EJABBERD Docker Container

--- a/installs/docker/Ejabberd/Dockerfile
+++ b/installs/docker/Ejabberd/Dockerfile
@@ -1,4 +1,6 @@
-FROM ejabberd/ecs:20.04
+#FROM ejabberd/ecs:20.04
+#FROM ugeek/ejabberd:arm64
+from sando38/docker-ejabberd-multiarch
 MAINTAINER David Lockwood
 
 # OSP Customized EJABBERD Docker Container

--- a/installs/docker/Ejabberd/Dockerfile
+++ b/installs/docker/Ejabberd/Dockerfile
@@ -1,6 +1,6 @@
 #FROM ejabberd/ecs:20.04
-#FROM ugeek/ejabberd:arm64
-from sando38/docker-ejabberd-multiarch
+FROM ugeek/ejabberd:arm64
+#FROM sando38/docker-ejabberd-multiarch
 MAINTAINER David Lockwood
 
 # OSP Customized EJABBERD Docker Container

--- a/installs/docker/Ejabberd/docker-files.d/ejabberd.yml
+++ b/installs/docker/Ejabberd/docker-files.d/ejabberd.yml
@@ -157,7 +157,7 @@ shaper_rules:
 
 auth_use_cache: false
 auth_password_format: scram
-extauth_program: "/usr/bin/python3 /home/ejabberd/conf/auth_osp.py"
+extauth_program: "/usr/bin/python3 /opt/ejabberd/conf/auth_osp.py"
 extauth_instances: 3
 
 host_config:

--- a/installs/docker/Ejabberd/docker-files.d/entrypoint.sh
+++ b/installs/docker/Ejabberd/docker-files.d/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-cp -u -p /home/ejabberd/run/ejabberd.yml /home/ejabberd/conf/ejabberd.yml
-cp -u -p /home/ejabberd/run/auth_osp.py /home/ejabberd/conf/auth_osp.py
+cp -u -p /opt/ejabberd/run/ejabberd.yml /opt/ejabberd/conf/ejabberd.yml
+cp -u -p /opt/ejabberd/run/auth_osp.py /opt/ejabberd/conf/auth_osp.py
 
 # Configure ejabberd
 export EJABBERD_DOMAIN
-sed -i "s/CHANGEME/$EJABBERD_DOMAIN/g" /home/ejabberd/conf/ejabberd.yml
+sed -i "s/CHANGEME/$EJABBERD_DOMAIN/g" /opt/ejabberd/conf/ejabberd.yml
 
 #export EJABBERD_XMLRPC_ALLOWIP
 #IFS="," read -a XMLRPCARRAY <<< $EJABBERD_XMLRPC_ALLOWIP
@@ -13,12 +13,12 @@ sed -i "s/CHANGEME/$EJABBERD_DOMAIN/g" /home/ejabberd/conf/ejabberd.yml
 #do
 #      XMLRPCSTRING+="      - $i\n"
 #done
-#sed -i "s/ALLOWXMLRPC/$XMLRPCSTRING/g" /home/ejabberd/conf/ejabberd.yml
+#sed -i "s/ALLOWXMLRPC/$XMLRPCSTRING/g" /opt/ejabberd/conf/ejabberd.yml
 
 export OSP_API_PROTOCOL
 export OSP_API_DOMAIN
 export EJABBERD_PASSWORD
 
-chown -R ejabberd:ejabberd /home/ejabberd
+chown -R ejabberd:ejabberd /opt/ejabberd
 
 supervisord --nodaemon --configuration /run/supervisord.conf

--- a/installs/docker/Ejabberd/docker-files.d/supervisord.conf
+++ b/installs/docker/Ejabberd/docker-files.d/supervisord.conf
@@ -2,18 +2,18 @@
 nodaemon=true
 
 [program:ejabberdctl]
-directory=/home/ejabberd/bin/
+directory=/opt/ejabberd/
 user=ejabberd
 group=ejabberd
-command=/home/ejabberd/bin/ejabberdctl foreground
+command=/usr/local/bin/ejabberdctl foreground
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:ejabberdConfig]
-directory=/home/ejabberd/bin/
+directory=/opt/ejabberd/
 user=ejabberd
 group=ejabberd
 autorestart=false
-command=bash -c "sleep 30 && exec /home/ejabberd/bin/ejabberdctl register admin localhost %(ENV_EJABBERD_PASSWORD)s"
+command=bash -c "sleep 30 && exec /usr/local/bin/ejabberdctl register admin localhost %(ENV_EJABBERD_PASSWORD)s"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/installs/docker/docker-compose.yml
+++ b/installs/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     #  - "traefik.http.routers.ejabberd.tls.certresolver=le"
     #  - "traefik.http.services.ejabberd.loadbalancer.server.port=5280"
     volumes:
-    - "/srv/docker/osp-app/data/ejabberd/database:/home/ejabberd/database"
+    - "/srv/docker/osp-app/data/ejabberd/database:/opt/ejabberd/database"
     networks:
       - osp
       - web


### PR DESCRIPTION
This pull requests contains the implementation of Github actions builds that allow to use the OpenStreamingPlatform on Raspberry PI.

Some changes I've done:
1. Changed the Ejabberd image from `ejabberd/ecs:20.04` to `andrejunqueira33/ejabberd-new:1.0.0`. I believe the image is older and might not contain all latest Ejabberd things but as I'm not exactly sure what this stuff is used for it might or might not be okay. The reason we need to switch away from the official image is because it doesn't have ARM builds.
2. Added Github Actions builds. Currently these build the images on every checkin (which should be done in my opinion) and then push the image on every checkin on master (which in my opinion is also fine, but is more debatable). The version is currently set to 1.0.x (where x++ for every build). All these are of course up for debate and can be changed as desirable.
3. It needs a repository secret to actually push to your Dockerhub:
![image](https://user-images.githubusercontent.com/2350015/209737124-f626f59a-498b-4298-bcf9-22a358d26e76.png)


Btw, for the Dockerbuilds I do personally think that these should ideally work on a clean repository. Currently you'd have to run the `./build-docker-directory.sh` script first, but from my experience, just placing the Dockerfiles in the places where no such thing is required anymore would be prefered.